### PR TITLE
Added weak delegate to remove strong referenc cycle.

### DIFF
--- a/DynamicTextView/ruuiDynamicTextView.swift
+++ b/DynamicTextView/ruuiDynamicTextView.swift
@@ -33,6 +33,10 @@ class ruuiDynamicTextView: UITextView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    deinit {
+        NSNotificationCenter.defaultCenter().removeObserver(self)
+    }
+    
     override func layoutSubviews() {
         super.layoutSubviews()
         

--- a/DynamicTextView/ruuiDynamicTextView.swift
+++ b/DynamicTextView/ruuiDynamicTextView.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 class ruuiDynamicTextView: UITextView {
-    var dynamicDelegate: ruuiDynamicTextViewDelegate?
+    weak var dynamicDelegate: ruuiDynamicTextViewDelegate?
     var minHeight: CGFloat!
     var maxHeight: CGFloat?
     private var contentOffsetCenterY: CGFloat!
@@ -17,14 +17,14 @@ class ruuiDynamicTextView: UITextView {
     init(frame: CGRect, offset: CGFloat = 0.0) {
         super.init(frame: frame, textContainer: nil)
         minHeight = frame.size.height
-
+        
         //center first line
         let size = self.sizeThatFits(CGSizeMake(self.bounds.size.width, CGFloat.max))
         contentOffsetCenterY = (-(frame.size.height - size.height * self.zoomScale) / 2.0) + offset
-
+        
         //listen for text changes
         NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(textChanged), name: UITextViewTextDidChangeNotification, object: nil)
-
+        
         //update offsets
         layoutSubviews()
     }
@@ -57,7 +57,7 @@ class ruuiDynamicTextView: UITextView {
             self.contentOffset.y = updateContentOffsetY!
         }
     }
-
+    
     func textChanged() {
         let caretRect = self.caretRectForPosition(self.selectedTextRange!.start)
         let overflow = caretRect.size.height + caretRect.origin.y - (self.contentOffset.y + self.bounds.size.height - self.contentInset.bottom - self.contentInset.top)
@@ -71,6 +71,6 @@ class ruuiDynamicTextView: UITextView {
     }
 }
 
-protocol ruuiDynamicTextViewDelegate {
+protocol ruuiDynamicTextViewDelegate: NSObjectProtocol {
     func dynamicTextViewDidResizeHeight(textview: ruuiDynamicTextView, height: CGFloat)
 }


### PR DESCRIPTION
Hey, great project.
I added your view in a ViewController that was opened and closed.
I also added a destructor to see weather it is called when the ViewController was dismissed.
It was not in the original code.

The reason is the strong reference cycle from UIViewController that has a var textView:ruuiDynamicTextView and the textView heaving a reference to the UIViewController as the delegate.

Now the deinit is called (is set a breakpoint). I also used it to remove the observer from NotificationCenter.

I also would like to inform you that I have tested the class on an iOS 8.3.1 device.

Simon
